### PR TITLE
Fixed the prefix

### DIFF
--- a/redis_enterprise_prometheus/assets/dashboards/redis_enterprise-prometheus_shard.json
+++ b/redis_enterprise_prometheus/assets/dashboards/redis_enterprise-prometheus_shard.json
@@ -439,7 +439,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:rdse.redis_process_resident_memory_bytes{$cluster,$db} by {redis}"
+                      "query": "avg:rdse2.redis_process_resident_memory_bytes{$cluster,$db} by {redis}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -494,7 +494,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:rdse.redis_process_virtual_memory_bytes{$cluster,$db} by {redis}"
+                      "query": "avg:rdse2.redis_process_virtual_memory_bytes{$cluster,$db} by {redis}"
                     }
                   ],
                   "response_format": "timeseries",


### PR DESCRIPTION
Fixed the prefix for the redis_process_resident_memory_bytes and redis_process_virtual_memory_bytes metrics.

### What does this PR do?

Fixed the prefix for the redis_process_resident_memory_bytes and redis_process_virtual_memory_bytes metrics.

### Motivation

Adopting Redis Prometheus V2 metrics.